### PR TITLE
Implements `OpenApiEndpointSource` and `SwaggerEndpointSource` which …

### DIFF
--- a/openapi-meta/src/main/java/com/networknt/openapi/OpenApiEndpointSource.java
+++ b/openapi-meta/src/main/java/com/networknt/openapi/OpenApiEndpointSource.java
@@ -1,0 +1,62 @@
+package com.networknt.openapi;
+
+import com.networknt.handler.config.EndpointSource;
+import com.networknt.oas.model.Path;
+import com.networknt.oas.model.Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Lists endpoints defined in the OpenApi spec parsed by OpenApiHelper.
+ */
+public class OpenApiEndpointSource implements EndpointSource {
+
+    private static final Logger log = LoggerFactory.getLogger(OpenApiEndpointSource.class);
+
+    @Override
+    public Iterable<Endpoint> listEndpoints() {
+
+        List<Endpoint> endpoints = new ArrayList<>();
+        String basePath = findBasePath();
+        Map<String, Path> paths = OpenApiHelper.openApi3.getPaths();
+
+
+        if(log.isInfoEnabled()) log.info("Generating paths from OpenApi spec");
+        for (Map.Entry<String, Path> pathPair : paths.entrySet()) {
+            String path = pathPair.getKey();
+            for (String method : pathPair.getValue().getOperations().keySet()) {
+                Endpoint endpoint = new Endpoint(basePath + path, method);
+                if(log.isDebugEnabled()) log.debug(endpoint.toString());
+                endpoints.add(endpoint);
+            }
+        }
+        return endpoints;
+    }
+
+    public String findBasePath() {
+        List<Server> servers = OpenApiHelper.openApi3.getServers();
+        if(servers.isEmpty()) {
+            log.warn("No server found in OpenApi spec. Using empty base path for API.");
+            return "";
+        }
+
+        Server server = servers.get(0);
+        String url = null;
+        try {
+            url = server.getUrl();
+            URL urlObj = new URL(url);
+            String basePath = urlObj.getPath();
+            while (basePath.endsWith("/")) {
+                basePath = basePath.substring(0, basePath.length() - 1);
+            }
+            return basePath;
+        } catch (Exception e) {
+            throw new RuntimeException("Malformed servers[0].url in OpenApi spec: " + url, e);
+        }
+    }
+}

--- a/openapi-meta/src/test/java/com/networknt/openapi/OpenApiEndpointSourceTest.java
+++ b/openapi-meta/src/test/java/com/networknt/openapi/OpenApiEndpointSourceTest.java
@@ -1,0 +1,45 @@
+package com.networknt.openapi;
+
+import com.networknt.handler.config.EndpointSource;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class OpenApiEndpointSourceTest {
+
+    @Test
+    public void testFindBasePath() {
+        OpenApiEndpointSource source = new OpenApiEndpointSource();
+        String basePath = source.findBasePath();
+        Assert.assertEquals("/v1", basePath);
+    }
+
+    @Test
+    public void testPetstoreEndpoints() {
+        OpenApiEndpointSource source = new OpenApiEndpointSource();
+        Iterable<EndpointSource.Endpoint> endpoints = source.listEndpoints();
+
+        // Extract a set of string representations of endpoints
+        Set<String> endpointStrings = StreamSupport
+            .stream(endpoints.spliterator(), false)
+            .map(Object::toString)
+            .collect(Collectors.toSet());
+
+        // Assert that we got what we wanted
+        Assert.assertEquals(
+            new HashSet<>(Arrays.asList(
+                "/v1/pets@get",
+                "/v1/pets@post",
+                "/v1/pets/{petId}@get",
+                "/v1/pets/{petId}@delete"
+            )),
+            endpointStrings
+        );
+    }
+
+}

--- a/swagger-meta/src/main/java/com/networknt/swagger/SwaggerEndpointSource.java
+++ b/swagger-meta/src/main/java/com/networknt/swagger/SwaggerEndpointSource.java
@@ -1,0 +1,57 @@
+package com.networknt.swagger;
+
+import com.networknt.handler.config.EndpointSource;
+import io.swagger.models.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class SwaggerEndpointSource implements EndpointSource {
+
+    private static final Logger log = LoggerFactory.getLogger(SwaggerEndpointSource.class);
+
+    @Override
+    public Iterable<Endpoint> listEndpoints() {
+
+        List<Endpoint> endpoints = new ArrayList<>();
+        String basePath = findBasePath();
+        Map<String, Path> paths = SwaggerHelper.swagger.getPaths();
+
+        if(log.isInfoEnabled()) log.info("Generating paths from Swagger spec");
+        for (Map.Entry<String, Path> pathPair : paths.entrySet()) {
+            String path = basePath + pathPair.getKey();
+            Path pathImpl = pathPair.getValue();
+
+            if(pathImpl.getGet() != null) addEndpoint(endpoints, path, "get");
+            if(pathImpl.getPut() != null) addEndpoint(endpoints, path, "put");
+            if(pathImpl.getHead() != null) addEndpoint(endpoints, path, "head");
+            if(pathImpl.getPost() != null) addEndpoint(endpoints, path, "post");
+            if(pathImpl.getDelete() != null) addEndpoint(endpoints, path, "delete");
+            if(pathImpl.getPatch() != null) addEndpoint(endpoints, path, "patch");
+            if(pathImpl.getOptions() != null) addEndpoint(endpoints, path, "options");
+        }
+        return endpoints;
+    }
+
+    private static void addEndpoint(List<Endpoint> endpoints, String path, String method) {
+        Endpoint endpoint = new Endpoint(path, method);
+        if(log.isDebugEnabled()) log.debug(endpoint.toString());
+        endpoints.add(endpoint);
+    }
+
+    public String findBasePath() {
+        String basePath = SwaggerHelper.swagger.getBasePath();
+        if(basePath == null) {
+            log.warn("No basePath found in Swagger spec. Using empty base path for API.");
+            return "";
+        }
+        while (basePath.endsWith("/")) {
+            basePath = basePath.substring(0, basePath.length() - 1);
+        }
+        return basePath;
+    }
+
+}

--- a/swagger-meta/src/test/java/com/networknt/swagger/SwaggerEndpointSourceTest.java
+++ b/swagger-meta/src/test/java/com/networknt/swagger/SwaggerEndpointSourceTest.java
@@ -1,0 +1,66 @@
+package com.networknt.swagger;
+
+import com.networknt.handler.config.EndpointSource;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Lists endpoints defined in the Swagger spec parsed by SwaggerHelper.
+ */
+public class SwaggerEndpointSourceTest {
+
+    @Test
+    public void testFindBasePath() {
+        SwaggerEndpointSource source = new SwaggerEndpointSource();
+        String basePath = source.findBasePath();
+        Assert.assertEquals("/v2", basePath);
+    }
+
+    @Test
+    public void testPetstoreEndpoints() {
+        SwaggerEndpointSource source = new SwaggerEndpointSource();
+        Iterable<EndpointSource.Endpoint> endpoints = source.listEndpoints();
+
+        // Extract a set of string representations of endpoints
+        Set<String> endpointStrings = StreamSupport
+            .stream(endpoints.spliterator(), false)
+            .map(Object::toString)
+            .collect(Collectors.toSet());
+
+        // Assert that we got what we wanted
+        Assert.assertEquals(
+            new HashSet<>(Arrays.asList(
+                "/v2/store/inventory@get",
+                "/v2/store/order@post",
+                "/v2/store/order/{orderId}@get",
+                "/v2/store/order/{orderId}@delete",
+
+                "/v2/user@post",
+                "/v2/user/logout@get",
+                "/v2/user/login@get",
+                "/v2/user/createWithList@post",
+                "/v2/user/createWithArray@post",
+                "/v2/user/{username}@delete",
+                "/v2/user/{username}@put",
+                "/v2/user/{username}@get",
+
+                "/v2/pet@post",
+                "/v2/pet@put",
+                "/v2/pet/findByStatus@get",
+                "/v2/pet/findByTags@get",
+                "/v2/pet/{petId}@delete",
+                "/v2/pet/{petId}@get",
+                "/v2/pet/{petId}@post",
+                "/v2/pet/{petId}/uploadImage@post"
+            )),
+            endpointStrings
+        );
+    }
+
+}


### PR DESCRIPTION
…generate the list of endpoints found in the API spec parsed by `OpenApiHelper` and `SwaggerHelper` respectively.

This depends on https://github.com/networknt/light-4j/pull/282 and the build can be expected to fail until that is merged.

the change allows this sort of configuration:
```yaml
- source: com.networknt.openapi.OpenApiEndpointSource
  exec:
  - my-openapi-chain
```

It logs the resolution at startup like so (from my eval project):
```
folder for validator.yml
12:54:08.311 [main] is.thing.usernotes-1.0.0  INFO  c.n.openapi.OpenApiEndpointSource listEndpoints - Generating paths from OpenApi spec
12:54:08.312 [main] is.thing.usernotes-1.0.0  DEBUG c.n.openapi.OpenApiEndpointSource listEndpoints - /usernotes/v1/users@get
12:54:08.312 [main] is.thing.usernotes-1.0.0  DEBUG c.n.openapi.OpenApiEndpointSource listEndpoints - /usernotes/v1/users@post
12:54:08.312 [main] is.thing.usernotes-1.0.0  DEBUG c.n.openapi.OpenApiEndpointSource listEndpoints - /usernotes/v1/users/{userId}@get
12:54:08.312 [main] is.thing.usernotes-1.0.0  DEBUG c.n.openapi.OpenApiEndpointSource listEndpoints - /usernotes/v1/users/{userId}@put
12:54:08.312 [main] is.thing.usernotes-1.0.0  DEBUG c.n.openapi.OpenApiEndpointSource listEndpoints - /usernotes/v1/users/{userId}@delete
12:54:08.312 [main] is.thing.usernotes-1.0.0  DEBUG c.n.openapi.OpenApiEndpointSource listEndpoints - /usernotes/v1/notes@get
12:54:08.313 [main] is.thing.usernotes-1.0.0  DEBUG c.n.openapi.OpenApiEndpointSource listEndpoints - /usernotes/v1/notes@post
12:54:08.313 [main] is.thing.usernotes-1.0.0  DEBUG c.n.openapi.OpenApiEndpointSource listEndpoints - /usernotes/v1/notes/{noteId}@get
12:54:08.313 [main] is.thing.usernotes-1.0.0  DEBUG c.n.openapi.OpenApiEndpointSource listEndpoints - /usernotes/v1/notes/{noteId}@put
12:54:08.313 [main] is.thing.usernotes-1.0.0  DEBUG c.n.openapi.OpenApiEndpointSource listEndpoints - /usernotes/v1/notes/{noteId}@delete
12:54:08.313 [main] is.thing.usernotes-1.0.0  DEBUG c.n.openapi.OpenApiEndpointSource listEndpoints - /usernotes/v1/notes/{noteId}/sections@get
12:54:08.313 [main] is.thing.usernotes-1.0.0  DEBUG c.n.openapi.OpenApiEndpointSource listEndpoints - /usernotes/v1/notes/{noteId}/sections/{sectionId}@get
```
