### PR TITLE
Fixed validation of path parameters and query parameters

### DIFF
--- a/openapi-validator/src/main/java/com/networknt/openapi/RequestValidator.java
+++ b/openapi-validator/src/main/java/com/networknt/openapi/RequestValidator.java
@@ -125,15 +125,12 @@ public class RequestValidator {
 
             final String paramName = openApiOperation.getPathString().paramName(i);
 
-            String decodeParamValue = null;
-
+            String paramValue = requestPath.part(i); // If it can't be UTF-8 decoded, use directly.
             try {
-                decodeParamValue = URLDecoder.decode(requestPath.part(i), "UTF-8");
+                paramValue = URLDecoder.decode(requestPath.part(i), "UTF-8");
             } catch (Exception e) {
                 logger.info("Path parameter cannot be decoded, it will be used directly");
             }
-
-            final String paramValue = (decodeParamValue == null) ? requestPath.part(i) : decodeParamValue;
 
             final Optional<Parameter> parameter = openApiOperation.getOperation().getParameters()
                     .stream()
@@ -176,6 +173,9 @@ public class RequestValidator {
             if(queryParameter.getRequired()) {
                 return new Status(VALIDATOR_REQUEST_PARAMETER_QUERY_MISSING, queryParameter.getName(), openApiOperation.getPathString().original());
             }
+        // Validate the value contains by queryParameterValue, if it is the only elements inside the array deque.
+        // Since if the queryParameterValue's length smaller than 2, it means the query parameter is not an array,
+        // thus not necessary to apply array validation to this value.
         } else if (queryParameterValues.size() < 2) {
 
             Optional<Status> optional = queryParameterValues
@@ -186,6 +186,9 @@ public class RequestValidator {
             if(optional.isPresent()) {
                 return optional.get();
             }
+        // Validate the queryParameterValue directly instead of validating its elements, if the length of this array deque larger than 2.
+        // Since if the queryParameterValue's length larger than 2, it means the query parameter is an array.
+        // thus array validation should be applied, for example, validate the length of the array.
         } else {
             Status status = schemaValidator.validate(queryParameterValues, Overlay.toJson((SchemaImpl)queryParameter.getSchema()));
             Optional<Status> optional = Optional.ofNullable(status);


### PR DESCRIPTION
@NicholasAzar @stevehu Since the RequestValidator depends on json-schema-validator. There is another PR related to this issue can be found in networknt/json-schema-validator repo. These changes in different repo contributions to the same issue.

RFC which specifies the details of fix can be found here: https://github.com/networknt/light-rfcs/blob/master/light-rest-4j/0001-openapi-validator-bug-fix.md