### PR TITLE
Feat/response validation in ValidatorHandler

### DIFF
--- a/openapi-validator/pom.xml
+++ b/openapi-validator/pom.xml
@@ -107,6 +107,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>dump</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/openapi-validator/pom.xml
+++ b/openapi-validator/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>com.networknt</groupId>
+            <artifactId>dump</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
             <artifactId>json-overlay</artifactId>
         </dependency>
         <dependency>
@@ -106,10 +110,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.networknt</groupId>
-            <artifactId>dump</artifactId>
         </dependency>
     </dependencies>
 

--- a/openapi-validator/src/main/java/com/networknt/openapi/ResponseValidator.java
+++ b/openapi-validator/src/main/java/com/networknt/openapi/ResponseValidator.java
@@ -214,9 +214,9 @@ public class ResponseValidator {
         Status status = validateHeaders(exchange, openApiOperation, statusCode);
         if(status != null) return status;
 
-        Object body = exchange.getAttachment(StoreResponseStreamSinkConduit.RESPONSE);
+        byte[] responseBody = exchange.getAttachment(StoreResponseStreamSinkConduit.RESPONSE);
         String mediaType = exchange.getResponseHeaders().get(Headers.CONTENT_TYPE) == null ? "" : exchange.getResponseHeaders().get(Headers.CONTENT_TYPE).getFirst();
-
+        String body = responseBody == null ? null : new String(responseBody);
         status = validateResponseContent(body, openApiOperation, statusCode, mediaType);
 
         return status;

--- a/openapi-validator/src/main/java/com/networknt/openapi/ResponseValidator.java
+++ b/openapi-validator/src/main/java/com/networknt/openapi/ResponseValidator.java
@@ -68,9 +68,20 @@ public class ResponseValidator {
      * validate a given response content object with status code "200" and media content type "application/json"
      * uri, httpMethod, JSON_MEDIA_TYPE("200"), DEFAULT_MEDIA_TYPE("application/json") is to locate the schema to validate
      * @param responseContent response content needs to be validated
+     * @param exchange HttpServerExchange in handler
+     * @return Status return null if no validation errors
+     */
+    public Status validateResponseContent(Object responseContent, HttpServerExchange exchange) {
+        return validateResponseContent(responseContent, exchange.getRequestURI(), exchange.getRequestMethod().toString().toLowerCase(), GOOD_STATUS_CODE);
+    }
+
+    /**
+     * validate a given response content object with status code "200" and media content type "application/json"
+     * uri, httpMethod, JSON_MEDIA_TYPE("200"), DEFAULT_MEDIA_TYPE("application/json") is to locate the schema to validate
+     * @param responseContent response content needs to be validated
      * @param uri original uri of the request
      * @param httpMethod eg. "put" or "get"
-     * @return Status
+     * @return Status return null if no validation errors
      */
     public Status validateResponseContent(Object responseContent, String uri, String httpMethod) {
         return validateResponseContent(responseContent, uri, httpMethod, GOOD_STATUS_CODE);
@@ -83,7 +94,7 @@ public class ResponseValidator {
      * @param uri original uri of the request
      * @param httpMethod eg. "put" or "get"
      * @param statusCode eg. 200, 400
-     * @return Status
+     * @return Status return null if no validation errors
      */
     public Status validateResponseContent(Object responseContent, String uri, String httpMethod, String statusCode) {
         return validateResponseContent(responseContent, uri, httpMethod, statusCode, JSON_MEDIA_TYPE);
@@ -97,7 +108,7 @@ public class ResponseValidator {
      * @param httpMethod eg. "put" or "get"
      * @param statusCode eg. 200, 400
      * @param mediaTypeName eg. "application/json"
-     * @return Status
+     * @return Status return null if no validation errors
      */
     public Status validateResponseContent(Object responseContent, String uri, String httpMethod, String statusCode, String mediaTypeName) {
         OpenApiOperation operation = null;
@@ -119,7 +130,7 @@ public class ResponseValidator {
      * @param openApiOperation OpenApi Operation which is located by uri and httpMethod
      * @param statusCode eg. 200, 400
      * @param mediaTypeName eg. "application/json"
-     * @return Status
+     * @return Status return null if no validation errors
      */
     public Status validateResponseContent(Object responseContent, OpenApiOperation openApiOperation, String statusCode, String mediaTypeName) {
         //try to convert json string to structured object

--- a/openapi-validator/src/main/java/com/networknt/openapi/ResponseValidator.java
+++ b/openapi-validator/src/main/java/com/networknt/openapi/ResponseValidator.java
@@ -72,7 +72,7 @@ public class ResponseValidator {
      * @return Status return null if no validation errors
      */
     public Status validateResponseContent(Object responseContent, HttpServerExchange exchange) {
-        return validateResponseContent(responseContent, exchange.getRequestURI(), exchange.getRequestMethod().toString().toLowerCase(), GOOD_STATUS_CODE);
+        return validateResponseContent(responseContent, exchange.getRequestURI(), exchange.getRequestMethod().toString().toLowerCase(), String.valueOf(exchange.getStatusCode()));
     }
 
     /**

--- a/openapi-validator/src/main/java/com/networknt/openapi/ResponseValidator.java
+++ b/openapi-validator/src/main/java/com/networknt/openapi/ResponseValidator.java
@@ -18,11 +18,15 @@ package com.networknt.openapi;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.networknt.config.Config;
+import com.networknt.dump.StoreResponseStreamSinkConduit;
 import com.networknt.jsonoverlay.Overlay;
 import com.networknt.oas.model.*;
 import com.networknt.oas.model.impl.SchemaImpl;
 import com.networknt.schema.SchemaValidatorsConfig;
 import com.networknt.status.Status;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderValues;
+import io.undertow.util.Headers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,12 +35,16 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
 
 public class ResponseValidator {
     private final SchemaValidator schemaValidator;
     private final SchemaValidatorsConfig config;
     private static final String VALIDATOR_RESPONSE_CONTENT_UNEXPECTED = "ERR11018";
+    private static final String REQUIRED_RESPONSE_HEADER_MISSING = "ERR11019";
     private static final String JSON_MEDIA_TYPE = "application/json";
     private static final String GOOD_STATUS_CODE = "200";
     private static final String DEFAULT_STATUS_CODE = "default";
@@ -194,6 +202,62 @@ public class ResponseValidator {
                 schema = mediaType.get().getSchema();
                 JsonNode schemaNode = schema == null ? null : Overlay.toJson((SchemaImpl)schema);
                 return schemaNode;
+            }
+        }
+        return null;
+    }
+
+    public Status validateResponse(HttpServerExchange exchange, OpenApiOperation openApiOperation) {
+        requireNonNull(exchange, "An exchange is required");
+        requireNonNull(openApiOperation, "An OpenAPI operation is required");
+        String statusCode = String.valueOf(exchange.getStatusCode());
+        Status status = validateHeaders(exchange, openApiOperation, statusCode);
+        if(status != null) return status;
+
+        Object body = exchange.getAttachment(StoreResponseStreamSinkConduit.RESPONSE);
+        String mediaType = exchange.getResponseHeaders().get(Headers.CONTENT_TYPE) == null ? "" : exchange.getResponseHeaders().get(Headers.CONTENT_TYPE).getFirst();
+
+        status = validateResponseContent(body, openApiOperation, statusCode, mediaType);
+
+        return status;
+    }
+
+    private Status validateHeaders(HttpServerExchange exchange, OpenApiOperation operation, String statusCode) {
+        Optional<Response> response = Optional.ofNullable(operation.getOperation().getResponse(statusCode));
+        if(response.isPresent()) {
+            Map<String, Header> headerMap = response.get().getHeaders();
+            Optional<Status> optional = headerMap.entrySet()
+                    .stream()
+                    //based on OpenAPI specification, ignore "Content-Type" header
+                    //If a response header is defined with the name "Content-Type", it SHALL be ignored. - https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responseObject
+                    .filter(entry -> !Headers.CONTENT_TYPE_STRING.equals(entry.getKey()))
+                    .map(p -> validateHeader(exchange, p.getKey(), p.getValue()))
+                    .filter(s -> s != null)
+                    .findFirst();
+            if(optional.isPresent()) {
+                return optional.get();
+            }
+        }
+        return null;
+    }
+
+    private Status validateHeader(HttpServerExchange exchange, String headerName, Header operationHeader) {
+        final HeaderValues headerValues = exchange.getResponseHeaders().get(headerName);
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        //header won't tell if it's a real string or not. needs trying to convert.
+        config.setTypeLoose(true);
+        if ((headerValues == null || headerValues.isEmpty())) {
+            if(Boolean.TRUE.equals(operationHeader.getRequired())) {
+                return new Status(REQUIRED_RESPONSE_HEADER_MISSING, headerName);
+            }
+        } else {
+            Optional<Status> optional = headerValues
+                    .stream()
+                    .map((v) -> schemaValidator.validate(v, Overlay.toJson((SchemaImpl)operationHeader.getSchema()),  config))
+                    .filter(s -> s != null)
+                    .findFirst();
+            if(optional.isPresent()) {
+                return optional.get();
             }
         }
         return null;

--- a/openapi-validator/src/main/java/com/networknt/openapi/ValidatorConfig.java
+++ b/openapi-validator/src/main/java/com/networknt/openapi/ValidatorConfig.java
@@ -24,6 +24,7 @@ public class ValidatorConfig {
     boolean enabled;
     boolean logError;
     boolean skipBodyValidation = false;
+    boolean validateResponse;
 
     public ValidatorConfig() {
     }
@@ -46,5 +47,13 @@ public class ValidatorConfig {
 
     public void setSkipBodyValidation(boolean skipBodyValidation) {
         this.skipBodyValidation = skipBodyValidation;
+    }
+
+    public boolean isValidateResponse() {
+        return validateResponse;
+    }
+
+    public void setValidateResponse(boolean validateResponse) {
+        this.validateResponse = validateResponse;
     }
 }

--- a/openapi-validator/src/main/java/com/networknt/openapi/ValidatorHandler.java
+++ b/openapi-validator/src/main/java/com/networknt/openapi/ValidatorHandler.java
@@ -18,6 +18,7 @@ package com.networknt.openapi;
 
 import com.networknt.audit.AuditHandler;
 import com.networknt.config.Config;
+import com.networknt.dump.StoreResponseStreamSinkConduit;
 import com.networknt.handler.Handler;
 import com.networknt.handler.MiddlewareHandler;
 import com.networknt.status.Status;
@@ -59,9 +60,12 @@ public class ValidatorHandler implements MiddlewareHandler {
 
     RequestValidator requestValidator;
 
+    ResponseValidator responseValidator;
+
     public ValidatorHandler() {
         final SchemaValidator schemaValidator = new SchemaValidator(OpenApiHelper.openApi3);
         this.requestValidator = new RequestValidator(schemaValidator);
+        this.responseValidator = new ResponseValidator();
     }
 
     @Override
@@ -85,7 +89,22 @@ public class ValidatorHandler implements MiddlewareHandler {
             if(config.logError) logger.error("ValidationError:" + status.toString());
             return;
         }
+        if(config.validateResponse) {
+            validateResponse(exchange, openApiOperation);
+        }
         Handler.next(exchange, next);
+    }
+
+    private void validateResponse(HttpServerExchange exchange, OpenApiOperation openApiOperation) {
+        exchange.addResponseWrapper((factory, exchange12) -> new StoreResponseStreamSinkConduit(factory.create(), exchange12));
+
+        exchange.addExchangeCompleteListener((exchange1, nextListener) ->{
+            Status status = responseValidator.validateResponse(exchange, openApiOperation);
+            if(status != null) {
+                logger.error("Response validation error: {} \n with response body: {}", status.getDescription(), new String(exchange.getAttachment(StoreResponseStreamSinkConduit.RESPONSE)));
+            }
+            nextListener.proceed();
+        });
     }
 
     @Override

--- a/openapi-validator/src/main/resources/config/openapi-validator.yml
+++ b/openapi-validator/src/main/resources/config/openapi-validator.yml
@@ -6,3 +6,5 @@ enabled: true
 logError: true
 # Skip body validation set to true if used in light-router, light-proxy and light-spring-boot.
 skipBodyValidation: false
+# Enable response validation.
+validateResponse: false

--- a/openapi-validator/src/test/java/com/networknt/openapi/ForwardRequestHandler.java
+++ b/openapi-validator/src/test/java/com/networknt/openapi/ForwardRequestHandler.java
@@ -1,0 +1,33 @@
+package com.networknt.openapi;
+
+import com.networknt.body.BodyHandler;
+import com.networknt.config.Config;
+import com.networknt.handler.LightHttpHandler;
+import com.networknt.httpstring.ContentType;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import io.undertow.util.HttpString;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ForwardRequestHandler implements LightHttpHandler {
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        String responseBody = null;
+        if(exchange.getAttachment(BodyHandler.REQUEST_BODY) != null) {
+            responseBody = Config.getInstance().getMapper().writeValueAsString(exchange.getAttachment(BodyHandler.REQUEST_BODY));
+        }
+
+        List<HttpString> headerNames = exchange.getRequestHeaders().getHeaderNames().stream()
+                .filter( s -> s.toString().startsWith("todo"))
+                .collect(Collectors.toList());
+        for(HttpString headerName : headerNames) {
+            String headerValue = exchange.getRequestHeaders().get(headerName).getFirst();
+            exchange.getResponseHeaders().put(headerName, headerValue);
+        }
+        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, ContentType.APPLICATION_JSON.value());
+        exchange.getResponseSender().send(responseBody);
+    }
+}

--- a/openapi-validator/src/test/java/com/networknt/openapi/ResponseValidatorTest.java
+++ b/openapi-validator/src/test/java/com/networknt/openapi/ResponseValidatorTest.java
@@ -1,0 +1,93 @@
+package com.networknt.openapi;
+
+import com.networknt.body.BodyHandler;
+import com.networknt.config.Config;
+import com.networknt.exception.ClientException;
+import com.networknt.handler.LightHttpHandler;
+import com.networknt.status.Status;
+import io.undertow.Handlers;
+import io.undertow.Undertow;
+import io.undertow.client.ClientRequest;
+import io.undertow.client.ClientResponse;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Methods;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.networknt.openapi.ValidatorHandlerTest.sendResponse;
+
+public class ResponseValidatorTest {
+    static Map<String, Object> responses = Config.getInstance().getJsonMapConfig("responses");
+    static Undertow server = null;
+    ResponseValidator validator = new ResponseValidator();
+    static final Logger logger = LoggerFactory.getLogger(ResponseValidatorTest.class);
+    @Before
+    public void setUp() {
+        if(server == null) {
+            logger.info("starting server");
+            TestValidateResponseHandler testValidateResponseHandler = new TestValidateResponseHandler();
+            HttpHandler handler = Handlers.routing()
+                    .add(Methods.GET, "/v1/todoItems", testValidateResponseHandler);
+            ValidatorHandler validatorHandler = new ValidatorHandler();
+            validatorHandler.setNext(handler);
+            handler = validatorHandler;
+
+            BodyHandler bodyHandler = new BodyHandler();
+            bodyHandler.setNext(handler);
+            handler = bodyHandler;
+
+            OpenApiHandler openApiHandler = new OpenApiHandler();
+            openApiHandler.setNext(handler);
+            handler = openApiHandler;
+
+            server = Undertow.builder()
+                    .addHttpListener(8080, "localhost")
+                    .setHandler(handler)
+                    .build();
+            server.start();
+        }
+    }
+
+    @Test
+    public void testValidateResponseContentWithExchange() throws InterruptedException, ClientException, URISyntaxException, TimeoutException, ExecutionException {
+        ClientRequest clientRequest = new ClientRequest();
+        CompletableFuture<ClientResponse> future = sendResponse(clientRequest, "response1");
+        Assert.assertTrue(future.get(3, TimeUnit.SECONDS).getResponseCode() == 200);
+    }
+
+    @Test
+    public void testValidateResponseContentWithExchangeError() throws InterruptedException, ClientException, URISyntaxException, TimeoutException, ExecutionException {
+        ClientRequest clientRequest = new ClientRequest();
+        CompletableFuture<ClientResponse> future = sendResponse(clientRequest, "response2");
+        Assert.assertTrue(future.get(3, TimeUnit.SECONDS).getResponseCode() > 300);
+    }
+    public class TestValidateResponseHandler implements LightHttpHandler {
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+
+            String responseBody = null;
+            if(exchange.getAttachment(BodyHandler.REQUEST_BODY) != null) {
+                responseBody = Config.getInstance().getMapper().writeValueAsString(exchange.getAttachment(BodyHandler.REQUEST_BODY));
+            }
+            Status status = validator.validateResponseContent(responseBody, exchange);
+            if(status == null) {
+                exchange.getResponseSender().send("good");
+            } else {
+                exchange.setStatusCode(400);
+                exchange.getResponseSender().send("bad");
+            }
+        }
+    }
+}

--- a/openapi-validator/src/test/java/com/networknt/openapi/ValidatorHandlerTest.java
+++ b/openapi-validator/src/test/java/com/networknt/openapi/ValidatorHandlerTest.java
@@ -565,7 +565,7 @@ public class ValidatorHandlerTest {
         Assert.assertTrue(errorLines.size() > 0);
     }
 
-    private CompletableFuture<ClientResponse> sendResponse(ClientRequest request, String response) throws ClientException, URISyntaxException, InterruptedException {
+    public static CompletableFuture<ClientResponse> sendResponse(ClientRequest request, String response) throws ClientException, URISyntaxException, InterruptedException {
         final Http2Client client = Http2Client.getInstance();
         final ClientConnection connection;
         URI uri = new URI("http://localhost:8080");

--- a/openapi-validator/src/test/java/com/networknt/openapi/ValidatorHandlerTest.java
+++ b/openapi-validator/src/test/java/com/networknt/openapi/ValidatorHandlerTest.java
@@ -588,7 +588,7 @@ public class ValidatorHandlerTest {
         } finally {
             IoUtils.safeClose(connection);
         }
-        Thread.sleep(2000);
+        Thread.sleep(1200);
         return future;
     }
 

--- a/openapi-validator/src/test/resources/config/openapi-validator.yml
+++ b/openapi-validator/src/test/resources/config/openapi-validator.yml
@@ -8,3 +8,4 @@ enabled: true
 logError: true
 # Skip body validation set to true if used in light-router, light-proxy and light-spring-boot.
 skipBodyValidation: false
+validateResponse: true

--- a/openapi-validator/src/test/resources/config/openapi.yaml
+++ b/openapi-validator/src/test/resources/config/openapi.yaml
@@ -165,10 +165,11 @@ paths:
         '200':
           description: all todo items response
           headers:
-            customHeader1:
+            todo_Header1:
+              required: true
               schema:
                 type: string
-            customHeader2:
+            todo_Header2:
               schema:
                 type: integer
             Accept-Encoding:

--- a/openapi-validator/src/test/resources/config/openapi.yaml
+++ b/openapi-validator/src/test/resources/config/openapi.yaml
@@ -157,6 +157,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /todoItems:
+    get:
+      description: return all to-do items
+      operationId: getTodoItemList
+      responses:
+        '200':
+          description: all todo items response
+          headers:
+            customHeader1:
+              schema:
+                type: string
+            customHeader2:
+              schema:
+                type: integer
+            Accept-Encoding:
+              schema:
+                enum:
+                  - "*"
+            Content-Type:
+              schema:
+                enum:
+                  - application/json
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TodoItems'
+
 components:
   parameters:
     accessId:
@@ -209,3 +236,20 @@ components:
           format: int32
         message:
           type: string
+    TodoItems:
+        type: array
+        items:
+          $ref: '#/components/schemas/TodoItem'
+    TodoItem:
+      type: object
+      required:
+        - id
+        - content
+      properties:
+        id:
+          type: string
+        content:
+          type: string
+        date:
+          type: string
+          format: date

--- a/openapi-validator/src/test/resources/config/responses.yml
+++ b/openapi-validator/src/test/resources/config/responses.yml
@@ -1,0 +1,10 @@
+response1:
+  - id: 1a7f12c2-f591-4344-9c93-56d16cfdb0ce
+    content: response1
+    trace: 1
+  - id: 1b7f12c2-f591-4344-9c93-56d16cfdb0ce
+    content: response1
+    trace: 2
+response2:
+  - id: 2a7f12c2-f591-4344-9c93-56d16cfdb0ce
+    trace: 3

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <version.logback>1.2.3</version.logback>
         <version.junit>4.12</version.junit>
         <version.mockito>2.10.0</version.mockito>
+        <version.powermock>2.0.0</version.powermock>
         <version.undertow>2.0.16.Final</version.undertow>
         <version.swagger-parser>1.0.34</version.swagger-parser>
         <version.swagger-core>1.5.18</version.swagger-core>


### PR DESCRIPTION
related issue: https://github.com/networknt/light-rest-4j/issues/89
-Added response validation in validator handler.
-Added a config "validateResponse" in openapi-validator.yml to enable/disable response validation feature.
-When there's a validation error of response, it will only log the error. It cannot send the error back to the client because the response is already completed. Until we change the mechanism of sending a response, I think this is the only way.
-This feature is only suggested to be used in dev/sit environment due to multiple times duplicated serialization/deserialization.
-This feature should not affect any existing behaviours since it only adds a callback logging when the response completed.