### PR TITLE
Fixes #113 - Support parameterization of handling nullable fields

### DIFF
--- a/openapi-validator/src/main/java/com/networknt/openapi/RequestValidator.java
+++ b/openapi-validator/src/main/java/com/networknt/openapi/RequestValidator.java
@@ -119,6 +119,8 @@ public class RequestValidator {
         }
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
         config.setTypeLoose(false);
+        config.setHandleNullableField(ValidatorHandler.config.isHandleNullableField());
+        
         return schemaValidator.validate(requestBody, Overlay.toJson((SchemaImpl)specBody.getContentMediaType("application/json").getSchema()), config);
     }
     

--- a/openapi-validator/src/main/java/com/networknt/openapi/ResponseValidator.java
+++ b/openapi-validator/src/main/java/com/networknt/openapi/ResponseValidator.java
@@ -153,6 +153,7 @@ public class ResponseValidator {
             return new Status(VALIDATOR_RESPONSE_CONTENT_UNEXPECTED, openApiOperation.getMethod(), openApiOperation.getPathString().original());
         }
         config.setTypeLoose(false);
+        config.setHandleNullableField(ValidatorHandler.config.isHandleNullableField());
         return schemaValidator.validate(responseContent, schema, config);
     }
 
@@ -257,6 +258,7 @@ public class ResponseValidator {
         SchemaValidatorsConfig config = new SchemaValidatorsConfig();
         //header won't tell if it's a real string or not. needs trying to convert.
         config.setTypeLoose(true);
+        config.setHandleNullableField(ValidatorHandler.config.isHandleNullableField());
         if ((headerValues == null || headerValues.isEmpty())) {
             if(Boolean.TRUE.equals(operationHeader.getRequired())) {
                 return new Status(REQUIRED_RESPONSE_HEADER_MISSING, headerName);

--- a/openapi-validator/src/main/java/com/networknt/openapi/ValidatorConfig.java
+++ b/openapi-validator/src/main/java/com/networknt/openapi/ValidatorConfig.java
@@ -25,6 +25,7 @@ public class ValidatorConfig {
     boolean logError;
     boolean skipBodyValidation = false;
     boolean validateResponse;
+    boolean handleNullableField = true;
 
     public ValidatorConfig() {
     }
@@ -56,4 +57,12 @@ public class ValidatorConfig {
     public void setValidateResponse(boolean validateResponse) {
         this.validateResponse = validateResponse;
     }
+
+	public boolean isHandleNullableField() {
+		return handleNullableField;
+	}
+
+	public void setHandleNullableField(boolean handleNullableField) {
+		this.handleNullableField = handleNullableField;
+	}
 }

--- a/openapi-validator/src/main/resources/config/openapi-validator.yml
+++ b/openapi-validator/src/main/resources/config/openapi-validator.yml
@@ -8,3 +8,10 @@ logError: true
 skipBodyValidation: false
 # Enable response validation.
 validateResponse: false
+# When a field is set as nullable in the OpenAPI specification, the schema validator validates that it is nullable
+# however continues with validation against the nullable field
+ 
+# If handleNullableField is set to true && incoming field is nullable && value is field: null --> succeed
+# If handleNullableField is set to false && incoming field is nullable && value is field: null --> it is up to the type 
+# validator using the SchemaValidator to handle it.
+handleNullableField: true

--- a/openapi-validator/src/test/resources/config/openapi-validator.yml
+++ b/openapi-validator/src/test/resources/config/openapi-validator.yml
@@ -9,3 +9,11 @@ logError: true
 # Skip body validation set to true if used in light-router, light-proxy and light-spring-boot.
 skipBodyValidation: false
 validateResponse: true
+
+# When a field is set as nullable in the OpenAPI specification, the schema validator validates that it is nullable
+# however continues with validation against the nullable field
+ 
+# If handleNullableField is set to true && incoming field is nullable && value is field: null --> succeed
+# If handleNullableField is set to false && incoming field is nullable && value is field: null --> it is up to the type 
+# validator using the SchemaValidator to handle it.
+handleNullableField: true


### PR DESCRIPTION
This PR is a follow-up to issue #183 in json-schema-validator and allows configurable setting of the handling of nullable fields