### PR TITLE
inject additional spec to origin spec at the start up

### DIFF
--- a/openapi-helper/src/main/java/com/networknt/openapi/OpenApiHelper.java
+++ b/openapi-helper/src/main/java/com/networknt/openapi/OpenApiHelper.java
@@ -78,8 +78,8 @@ public class OpenApiHelper {
 
     /**
      * merge inject map to openapi map
-     * @param openapi
-     * @param inject
+     * @param openapi {@link Map} openapi
+     * @param inject {@link Map} openapi
      */
     public static void merge(Map<String, Object> openapi, Map<String, Object> inject) {
         if (inject == null) {
@@ -100,6 +100,9 @@ public class OpenApiHelper {
                 }
             } else if (o instanceof List && i instanceof List) {
                 ((List<Object>) o).addAll((List)i);
+            } else {
+                // if has the same key, return the injected
+                return i;
             }
             return o;
         }

--- a/openapi-helper/src/main/java/com/networknt/openapi/OpenApiHelper.java
+++ b/openapi-helper/src/main/java/com/networknt/openapi/OpenApiHelper.java
@@ -25,10 +25,8 @@ import org.slf4j.LoggerFactory;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.function.BiFunction;
 
 /**
  * This class load and cache openapi.json in a static block so that it can be
@@ -76,6 +74,35 @@ public class OpenApiHelper {
         }
         INSTANCE = new OpenApiHelper(spec);
         return INSTANCE;
+    }
+
+    /**
+     * merge inject map to openapi map
+     * @param openapi
+     * @param inject
+     */
+    public static void merge(Map<String, Object> openapi, Map<String, Object> inject) {
+        if (inject == null) {
+            return;
+        }
+        for (Map.Entry<String, Object> entry : inject.entrySet()) {
+            openapi.merge(entry.getKey(), entry.getValue(), new Merger());
+        }
+    }
+
+    // merge in case of map, add in case of list
+    static class Merger implements BiFunction {
+        @Override
+        public Object apply(Object o, Object i) {
+            if (o instanceof Map && i instanceof Map) {
+                for (Map.Entry<String, Object> entry : ((Map<String, Object>) i).entrySet()) {
+                    ((Map<String, Object>) o).merge(entry.getKey(), entry.getValue(), new Merger());
+                }
+            } else if (o instanceof List && i instanceof List) {
+                ((List<Object>) o).addAll((List)i);
+            }
+            return o;
+        }
     }
 
     public Optional<NormalisedPath> findMatchingApiPath(final NormalisedPath requestPath) {

--- a/openapi-helper/src/test/java/com/networknt/openapi/OpenApiHelperTest.java
+++ b/openapi-helper/src/test/java/com/networknt/openapi/OpenApiHelperTest.java
@@ -18,7 +18,13 @@ package com.networknt.openapi;
 
 import com.networknt.config.Config;
 import org.junit.Assert;
+import static org.junit.Assert.*;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Created by steve on 23/09/16.
@@ -36,4 +42,96 @@ public class OpenApiHelperTest {
     public void testBasePath() {
         Assert.assertEquals("/v1", OpenApiHelper.basePath);
     }
+
+    @Test
+    public void testMergeNull(){
+        Map<String, Object> openapi = Map.of("key", "val");
+        Map<String, Object> inject = null;
+        OpenApiHelper.merge(openapi, inject);
+        assertEquals(1, openapi.size());
+        assertEquals("val", openapi.get("key"));
+    }
+
+    @Test
+    public void testMergeMap(){
+        Map<String, Object> openapi = new HashMap<>();
+        Map<String, Object> inject = new HashMap<>();
+        openapi.put("key1", "val1");
+        inject.put("key2", "val2");
+        OpenApiHelper.merge(openapi, inject);
+        assertEquals(2, openapi.size());
+        assertEquals("val1", openapi.get("key1"));
+        assertEquals("val2", openapi.get("key2"));
+    }
+
+    @Test
+    public void testMergeMapOverwritten(){
+        Map<String, Object> openapi = new HashMap<>();
+        Map<String, Object> inject = new HashMap<>();
+        openapi.put("key1", "val1");
+        inject.put("key1", "val2");
+        OpenApiHelper.merge(openapi, inject);
+        assertEquals(1, openapi.size());
+        assertEquals("val2", openapi.get("key1"));
+    }
+
+    @Test
+    public void testNestedMap() {
+        Map<String, Object> openapi = new HashMap<>();
+        Map<String, Object> inject = new HashMap<>();
+        Map<String, Object> openapiNested = new HashMap<>();
+        Map<String, Object> injectNested = new HashMap<>();
+        openapi.put("commonKey", openapiNested);
+        openapiNested.put("oKey2", "oVal2");
+        inject.put("commonKey", injectNested);
+        injectNested.put("iKey2", "iVal2");
+
+        OpenApiHelper.merge(openapi, inject);
+
+        assertEquals(1, openapi.size());
+        Map<String, Object> commonMap = (Map<String, Object>) openapi.get("commonKey");
+        assertEquals(commonMap.size(), 2);
+        assertEquals("oVal2", commonMap.get("oKey2"));
+        assertEquals("iVal2", commonMap.get("iKey2"));
+    }
+
+    @Test
+    public void testNestedMapOverwritten() {
+        Map<String, Object> openapi = new HashMap<>();
+        Map<String, Object> inject = new HashMap<>();
+        Map<String, Object> openapiNested = new HashMap<>();
+        Map<String, Object> injectNested = new HashMap<>();
+        openapi.put("commonKey", openapiNested);
+        openapiNested.put("oKey2", "oVal2");
+        inject.put("commonKey", injectNested);
+        injectNested.put("oKey2", "iVal2");
+
+        OpenApiHelper.merge(openapi, inject);
+
+        assertEquals(1, openapi.size());
+        Map<String, Object> commonMap = (Map<String, Object>) openapi.get("commonKey");
+        assertEquals(commonMap.size(), 1);
+        assertEquals("iVal2", commonMap.get("oKey2"));
+    }
+
+    @Test
+    public void testNestedList() {
+        Map<String, Object> openapi = new HashMap<>();
+        Map<String, Object> inject = new HashMap<>();
+        List<Map<String, Object>> openapiNested = new ArrayList<>();
+        List<Map<String, Object>> injectNested = new ArrayList<>();
+        openapi.put("commonKey", openapiNested);
+        openapiNested.add(new HashMap<>(){{put("oKey2", "oVal2");}});
+        inject.put("commonKey", injectNested);
+        injectNested.add(new HashMap<>(){{put("iKey2", "iVal2");}});
+
+        OpenApiHelper.merge(openapi, inject);
+
+        assertEquals(1, openapi.size());
+        List<Map<String, Object>> commonList = (List<Map<String, Object>>) openapi.get("commonKey");
+        assertEquals(commonList.size(), 2);
+        assertEquals("oVal2", commonList.get(0).get("oKey2"));
+        assertEquals("iVal2", commonList.get(1).get("iKey2"));
+    }
+
 }

--- a/openapi-meta/src/main/java/com/networknt/openapi/DefaultInjectableSpecValidator.java
+++ b/openapi-meta/src/main/java/com/networknt/openapi/DefaultInjectableSpecValidator.java
@@ -1,0 +1,23 @@
+package com.networknt.openapi;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class DefaultInjectableSpecValidator implements InjectableSpecValidator{
+    public static String PATHS = "paths";
+    Logger logger = LoggerFactory.getLogger(DefaultInjectableSpecValidator.class);
+    @Override
+    public boolean isValid(Map<String, Object> openapi, Map<String, Object> inject) {
+        if (inject.get(PATHS) instanceof Map && openapi.get(PATHS) instanceof Map) {
+            for (Map.Entry<String, Object> path : ((Map<String, Object>) inject.get(PATHS)).entrySet()) {
+                if (((Map<String, Object>)openapi.get(PATHS)).containsKey(path.getKey())) {
+                    logger.error("you are trying to overwritten an existing path: {}", path.getKey());
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/openapi-meta/src/main/java/com/networknt/openapi/DefaultInjectableSpecValidator.java
+++ b/openapi-meta/src/main/java/com/networknt/openapi/DefaultInjectableSpecValidator.java
@@ -4,20 +4,33 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.Set;
 
-public class DefaultInjectableSpecValidator implements InjectableSpecValidator{
+public class DefaultInjectableSpecValidator implements InjectableSpecValidator {
     public static String PATHS = "paths";
     Logger logger = LoggerFactory.getLogger(DefaultInjectableSpecValidator.class);
+
     @Override
     public boolean isValid(Map<String, Object> openapi, Map<String, Object> inject) {
         if (inject == null) {
             return true;
         }
         if (inject.get(PATHS) instanceof Map && openapi.get(PATHS) instanceof Map) {
-            for (Map.Entry<String, Object> path : ((Map<String, Object>) inject.get(PATHS)).entrySet()) {
-                if (((Map<String, Object>)openapi.get(PATHS)).containsKey(path.getKey())) {
-                    logger.error("you are trying to overwritten an existing path: {}", path.getKey());
-                    return false;
+            // each path in injecting spec
+            for (Map.Entry<String, Object> injectPath : ((Map<String, Object>) inject.get(PATHS)).entrySet()) {
+                // if the path in injecting spec also exists in the original openapi spec
+                if (((Map<String, Object>) openapi.get(PATHS)).containsKey(injectPath.getKey())) {
+                    // get all the methods within the same path in the openapi spec and the injecting spec
+                    Map<String, Object> openapiPath = (Map<String, Object>) ((Map<String, Object>) openapi.get(PATHS)).get(injectPath.getKey());
+                    Set<String> openapiMethods = openapiPath.keySet();
+                    Set<String> injectMethods = ((Map<String, Object>) injectPath.getValue()).keySet();
+                    // compare if there are duplicates
+                    for (String injectMethod : injectMethods) {
+                        if (openapiMethods.contains(injectMethod)) {
+                            logger.error("you are trying to overwritten an existing path: {} with method: {}", injectPath.getKey(), injectMethod);
+                            return false;
+                        }
+                    }
                 }
             }
         }

--- a/openapi-meta/src/main/java/com/networknt/openapi/DefaultInjectableSpecValidator.java
+++ b/openapi-meta/src/main/java/com/networknt/openapi/DefaultInjectableSpecValidator.java
@@ -10,6 +10,9 @@ public class DefaultInjectableSpecValidator implements InjectableSpecValidator{
     Logger logger = LoggerFactory.getLogger(DefaultInjectableSpecValidator.class);
     @Override
     public boolean isValid(Map<String, Object> openapi, Map<String, Object> inject) {
+        if (inject == null) {
+            return true;
+        }
         if (inject.get(PATHS) instanceof Map && openapi.get(PATHS) instanceof Map) {
             for (Map.Entry<String, Object> path : ((Map<String, Object>) inject.get(PATHS)).entrySet()) {
                 if (((Map<String, Object>)openapi.get(PATHS)).containsKey(path.getKey())) {

--- a/openapi-meta/src/main/java/com/networknt/openapi/InjectableSpecValidator.java
+++ b/openapi-meta/src/main/java/com/networknt/openapi/InjectableSpecValidator.java
@@ -1,0 +1,7 @@
+package com.networknt.openapi;
+
+import java.util.Map;
+
+public interface InjectableSpecValidator {
+    boolean isValid(Map<String, Object> openapi, Map<String, Object> inject);
+}

--- a/openapi-meta/src/main/java/com/networknt/openapi/OpenApiHandler.java
+++ b/openapi-meta/src/main/java/com/networknt/openapi/OpenApiHandler.java
@@ -24,6 +24,7 @@ import com.networknt.httpstring.AttachmentConstants;
 import com.networknt.oas.model.Operation;
 import com.networknt.oas.model.Path;
 import com.networknt.openapi.parameter.ParameterDeserializer;
+import com.networknt.service.SingletonServiceFactory;
 import com.networknt.utility.Constants;
 import com.networknt.utility.ModuleRegistry;
 import io.undertow.Handlers;
@@ -66,6 +67,14 @@ public class OpenApiHandler implements MiddlewareHandler {
     public OpenApiHandler() {
         Map<String, Object> inject = Config.getInstance().getJsonMapConfig(SPEC_INJECT);
         Map<String, Object> openapi = Config.getInstance().getJsonMapConfig(CONFIG_NAME);
+        InjectableSpecValidator validator = SingletonServiceFactory.getBean(InjectableSpecValidator.class);
+        if (validator == null) {
+            validator = new DefaultInjectableSpecValidator();
+        }
+        if (!validator.isValid(openapi, inject)) {
+            logger.error("the original spec and injected spec has error, please check the validator {}", validator.getClass().getName());
+            throw new RuntimeException("inject spec error");
+        }
         OpenApiHelper.merge(openapi, inject);
         try {
             OpenApiHelper.init(Config.getInstance().getMapper().writeValueAsString(openapi));

--- a/openapi-meta/src/main/java/com/networknt/openapi/OpenApiHandler.java
+++ b/openapi-meta/src/main/java/com/networknt/openapi/OpenApiHandler.java
@@ -16,15 +16,7 @@
 
 package com.networknt.openapi;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.networknt.audit.AuditHandler;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.networknt.config.Config;
 import com.networknt.handler.Handler;
 import com.networknt.handler.MiddlewareHandler;
@@ -34,7 +26,6 @@ import com.networknt.oas.model.Path;
 import com.networknt.openapi.parameter.ParameterDeserializer;
 import com.networknt.utility.Constants;
 import com.networknt.utility.ModuleRegistry;
-
 import io.undertow.Handlers;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -42,6 +33,13 @@ import io.undertow.util.AttachmentKey;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.HeaderValues;
 import io.undertow.util.HttpString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * This is the handler that parses the OpenApi object based on uri and method
@@ -54,11 +52,9 @@ public class OpenApiHandler implements MiddlewareHandler {
     static final Logger logger = LoggerFactory.getLogger(OpenApiHandler.class);
 
     public static final String CONFIG_NAME = "openapi";
-    static final String OPENAPI_YML_CONFIG = "openapi.yml";
-    static final String OPENAPI_YAML_CONFIG = "openapi.yaml";
-    static final String OPENAPI_JSON_CONFIG = "openapi.json";
+    public static final String SPEC_INJECT = "openapi-inject";
 
-	public static final AttachmentKey<Map<String, Object>> DESERIALIZED_QUERY_PARAMETERS = AttachmentKey.create(Map.class);
+    public static final AttachmentKey<Map<String, Object>> DESERIALIZED_QUERY_PARAMETERS = AttachmentKey.create(Map.class);
 	public static final AttachmentKey<Map<String, Object>> DESERIALIZED_PATH_PARAMETERS = AttachmentKey.create(Map.class);
 	public static final AttachmentKey<Map<String, Object>> DESERIALIZED_HEADER_PARAMETERS = AttachmentKey.create(Map.class);
 	public static final AttachmentKey<Map<String, Object>> DESERIALIZED_COOKIE_PARAMETERS = AttachmentKey.create(Map.class);
@@ -68,16 +64,16 @@ public class OpenApiHandler implements MiddlewareHandler {
 
     private volatile HttpHandler next;
     public OpenApiHandler() {
-        String spec = Config.getInstance().getStringFromFile(OPENAPI_YML_CONFIG);
-        if(spec == null) {
-            spec = Config.getInstance().getStringFromFile(OPENAPI_YAML_CONFIG);
-            if(spec == null) {
-                spec = Config.getInstance().getStringFromFile(OPENAPI_JSON_CONFIG);
-            }
+        Map<String, Object> inject = Config.getInstance().getJsonMapConfig(SPEC_INJECT);
+        Map<String, Object> openapi = Config.getInstance().getJsonMapConfig(CONFIG_NAME);
+        OpenApiHelper.merge(openapi, inject);
+        try {
+            OpenApiHelper.init(Config.getInstance().getMapper().writeValueAsString(openapi));
+        } catch (JsonProcessingException e) {
+            logger.error("merge specification failed");
+            throw new RuntimeException("merge specification failed");
         }
-        OpenApiHelper.init(spec);
     }
-
 
     @Override
     public void handleRequest(final HttpServerExchange exchange) throws Exception {

--- a/openapi-meta/src/test/java/com/networknt/openapi/DefaultInjectableSpecValidatorTest.java
+++ b/openapi-meta/src/test/java/com/networknt/openapi/DefaultInjectableSpecValidatorTest.java
@@ -33,4 +33,22 @@ public class DefaultInjectableSpecValidatorTest {
         boolean isValid = validator.isValid(openapi, inject);
         Assert.assertTrue(isValid);
     }
+
+    @Test
+    public void testValidatorDuplicatePath() {
+        Map<String, Object> openapi = Config.getInstance().getJsonMapConfig("openapi");
+        Map<String, Object> inject = Config.getInstance().getJsonMapConfig("openapi-inject-test-dup-path");
+        DefaultInjectableSpecValidator validator = new DefaultInjectableSpecValidator();
+        boolean isValid = validator.isValid(openapi, inject);
+        Assert.assertTrue(isValid);
+    }
+
+    @Test
+    public void testValidatorDuplicateMethod() {
+        Map<String, Object> openapi = Config.getInstance().getJsonMapConfig("openapi");
+        Map<String, Object> inject = Config.getInstance().getJsonMapConfig("openapi-inject-test-dup-method");
+        DefaultInjectableSpecValidator validator = new DefaultInjectableSpecValidator();
+        boolean isValid = validator.isValid(openapi, inject);
+        Assert.assertFalse(isValid);
+    }
 }

--- a/openapi-meta/src/test/java/com/networknt/openapi/DefaultInjectableSpecValidatorTest.java
+++ b/openapi-meta/src/test/java/com/networknt/openapi/DefaultInjectableSpecValidatorTest.java
@@ -1,0 +1,27 @@
+package com.networknt.openapi;
+
+import com.networknt.config.Config;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class DefaultInjectableSpecValidatorTest {
+    @Test
+    public void testValidatorInValid() {
+        Map<String, Object> openapi = Config.getInstance().getJsonMapConfig("openapi");
+        Map<String, Object> inject = Config.getInstance().getJsonMapConfig("openapi-inject-test-neg");
+        DefaultInjectableSpecValidator validator = new DefaultInjectableSpecValidator();
+        boolean isValid = validator.isValid(openapi, inject);
+        Assert.assertFalse(isValid);
+    }
+
+    @Test
+    public void testValidatorValid() {
+        Map<String, Object> openapi = Config.getInstance().getJsonMapConfig("openapi");
+        Map<String, Object> inject = Config.getInstance().getJsonMapConfig("openapi-inject-test-pos");
+        DefaultInjectableSpecValidator validator = new DefaultInjectableSpecValidator();
+        boolean isValid = validator.isValid(openapi, inject);
+        Assert.assertTrue(isValid);
+    }
+}

--- a/openapi-meta/src/test/java/com/networknt/openapi/DefaultInjectableSpecValidatorTest.java
+++ b/openapi-meta/src/test/java/com/networknt/openapi/DefaultInjectableSpecValidatorTest.java
@@ -24,4 +24,13 @@ public class DefaultInjectableSpecValidatorTest {
         boolean isValid = validator.isValid(openapi, inject);
         Assert.assertTrue(isValid);
     }
+
+    @Test
+    public void testNoInject() {
+        Map<String, Object> openapi = Config.getInstance().getJsonMapConfig("openapi");
+        Map<String, Object> inject = null;
+        DefaultInjectableSpecValidator validator = new DefaultInjectableSpecValidator();
+        boolean isValid = validator.isValid(openapi, inject);
+        Assert.assertTrue(isValid);
+    }
 }

--- a/openapi-meta/src/test/resources/config/openapi-inject-test-dup-method.yml
+++ b/openapi-meta/src/test/resources/config/openapi-inject-test-dup-method.yml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+paths:
+  /pets/{petId}:
+    get:
+      security:
+        - api-scope:
+            - admim
+
+components:
+  securitySchemes:
+    api-scope:
+      flows:
+        clientCredentials:
+          scopes:
+            admin: orwritten

--- a/openapi-meta/src/test/resources/config/openapi-inject-test-dup-path.yml
+++ b/openapi-meta/src/test/resources/config/openapi-inject-test-dup-path.yml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+paths:
+  /pets/{petId}:
+    # the original spec does not contain put method
+    put:
+      security:
+        - api-scope:
+            - admim
+
+components:
+  securitySchemes:
+    api-scope:
+      flows:
+        clientCredentials:
+          scopes:
+            admin: orwritten

--- a/openapi-meta/src/test/resources/config/openapi-inject-test-neg.yml
+++ b/openapi-meta/src/test/resources/config/openapi-inject-test-neg.yml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+paths:
+  /pets/${badKey}:
+    get:
+      security:
+        - api-scope:
+            - admim
+
+components:
+  securitySchemes:
+    api-scope:
+      flows:
+        clientCredentials:
+          scopes:
+            admin: orwritten

--- a/openapi-meta/src/test/resources/config/openapi-inject-test-pos.yml
+++ b/openapi-meta/src/test/resources/config/openapi-inject-test-pos.yml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+paths:
+  /pets/${goodKey}:
+    get:
+      security:
+        - api-scope:
+            - admim
+
+components:
+  securitySchemes:
+    api-scope:
+      flows:
+        clientCredentials:
+          scopes:
+            admin: orwritten

--- a/openapi-meta/src/test/resources/config/values.yml
+++ b/openapi-meta/src/test/resources/config/values.yml
@@ -1,0 +1,2 @@
+badKey: "{petId}"
+goodKey: petId


### PR DESCRIPTION
resolves #169 
right now the specification will be injected from openapi-inject.yml at the start up
the injected value will:
- add to the map if original map doesn't has this key
- overwrite the original value has the same key
- add all new to the origin list