### PR TITLE
issue #173 move JwtVerifier from static block to constructor

### DIFF
--- a/openapi-security/src/main/java/com/networknt/openapi/JwtVerifyHandler.java
+++ b/openapi-security/src/main/java/com/networknt/openapi/JwtVerifyHandler.java
@@ -79,7 +79,7 @@ public class JwtVerifyHandler implements MiddlewareHandler, IJwtVerifyHandler {
         config = Config.getInstance().getJsonMapConfig(OPENAPI_SECURITY_CONFIG);
         // fallback to generic security.yml
         if(config == null) config = Config.getInstance().getJsonMapConfig(JwtVerifier.SECURITY_CONFIG);
-        jwtVerifier = new JwtVerifier(config);
+
     }
 
     private volatile HttpHandler next;
@@ -95,6 +95,7 @@ public class JwtVerifyHandler implements MiddlewareHandler, IJwtVerifyHandler {
             }
             OpenApiHelper.init(spec);
         }
+        jwtVerifier = new JwtVerifier(config);
     }
 
     @Override


### PR DESCRIPTION
resolves #173 
- move jwtVerifier initiation from static block to constructor so that if any failure it will stop the server.